### PR TITLE
[Feature] #7 - 여행 일정 등록/조회 API 구현

### DIFF
--- a/server/src/main/java/com/affles/watchout/server/domain/travel/controller/TravelController.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/travel/controller/TravelController.java
@@ -1,0 +1,28 @@
+package com.affles.watchout.server.domain.travel.controller;
+
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelRequest.CreateTravelRequest;
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelResponse.TravelInfoResponse;
+import com.affles.watchout.server.domain.travel.service.TravelService;
+import com.affles.watchout.server.global.common.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/travels")
+@RequiredArgsConstructor
+public class TravelController {
+
+    private final TravelService travelService;
+
+    @PostMapping
+    public ApiResponse<Void> createTravel(@RequestBody CreateTravelRequest request, HttpServletRequest httpRequest) {
+        travelService.createTravel(request, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping
+    public ApiResponse<TravelInfoResponse> getTravel(HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(travelService.getTravel(httpRequest));
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/travel/converter/TravelConverter.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/travel/converter/TravelConverter.java
@@ -1,0 +1,15 @@
+package com.affles.watchout.server.domain.travel.converter;
+
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelResponse.TravelInfoResponse;
+import com.affles.watchout.server.domain.travel.entity.Travel;
+
+public class TravelConverter {
+
+    public static TravelInfoResponse toTravelInfoResponse(Travel travel) {
+        return TravelInfoResponse.builder()
+                .travelId(travel.getTravelId())
+                .departDate(travel.getDepartDate())
+                .arriveDate(travel.getArriveDate())
+                .build();
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/travel/dto/TravelDTO.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/travel/dto/TravelDTO.java
@@ -1,0 +1,34 @@
+package com.affles.watchout.server.domain.travel.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDate;
+
+public class TravelDTO {
+
+    public static class TravelRequest {
+
+        @Getter
+        public static class CreateTravelRequest {
+            @NotNull
+            private LocalDate departDate;
+
+            @NotNull
+            private LocalDate arriveDate;
+        }
+    }
+
+    public static class TravelResponse {
+
+        @Getter
+        @Builder
+        @NoArgsConstructor
+        @AllArgsConstructor
+        public static class TravelInfoResponse {
+            private Long travelId;
+            private LocalDate departDate;
+            private LocalDate arriveDate;
+        }
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/travel/repository/TravelRepository.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/travel/repository/TravelRepository.java
@@ -1,7 +1,11 @@
 package com.affles.watchout.server.domain.travel.repository;
 
 import com.affles.watchout.server.domain.travel.entity.Travel;
+import com.affles.watchout.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TravelRepository extends JpaRepository<Travel, Long> {
+    Optional<Travel> findFirstByUser(User user); // 하나만 가져오기 위해 설정
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/travel/service/TravelService.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/travel/service/TravelService.java
@@ -1,0 +1,12 @@
+package com.affles.watchout.server.domain.travel.service;
+
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelRequest.CreateTravelRequest;
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelResponse.TravelInfoResponse;
+import jakarta.servlet.http.HttpServletRequest;
+
+public interface TravelService {
+
+    void createTravel(CreateTravelRequest request, HttpServletRequest httpServletRequest);
+
+    TravelInfoResponse getTravel(HttpServletRequest httpServletRequest);
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/travel/service/TravelServiceImpl.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/travel/service/TravelServiceImpl.java
@@ -1,0 +1,58 @@
+package com.affles.watchout.server.domain.travel.service;
+
+import com.affles.watchout.server.domain.travel.converter.TravelConverter;
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelRequest.CreateTravelRequest;
+import com.affles.watchout.server.domain.travel.dto.TravelDTO.TravelResponse.TravelInfoResponse;
+import com.affles.watchout.server.domain.travel.entity.Travel;
+import com.affles.watchout.server.domain.travel.repository.TravelRepository;
+import com.affles.watchout.server.domain.user.entity.User;
+import com.affles.watchout.server.domain.user.repository.UserRepository;
+import com.affles.watchout.server.global.exception.TravelException;
+import com.affles.watchout.server.global.exception.UserException;
+import com.affles.watchout.server.global.jwt.JwtUtil;
+import com.affles.watchout.server.global.status.ErrorStatus;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TravelServiceImpl implements TravelService {
+
+    private final TravelRepository travelRepository;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void createTravel(CreateTravelRequest request, HttpServletRequest httpServletRequest) {
+        if (request.getDepartDate() == null || request.getArriveDate() == null) {
+            throw new TravelException(ErrorStatus.TRAVEL_DATE_REQUIRED);
+        }
+        Long userId = jwtUtil.getUserId(jwtUtil.resolveToken(httpServletRequest));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        Travel travel = Travel.builder()
+                .user(user)
+                .departDate(request.getDepartDate())
+                .arriveDate(request.getArriveDate())
+                .build();
+
+        travelRepository.save(travel);
+    }
+
+    @Override
+    public TravelInfoResponse getTravel(HttpServletRequest httpServletRequest) {
+        Long userId = jwtUtil.getUserId(jwtUtil.resolveToken(httpServletRequest));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+
+        Travel travel = travelRepository.findFirstByUser(user)
+                .orElseThrow(() -> new TravelException(ErrorStatus.TRAVEL_NOT_FOUND));
+
+        return TravelConverter.toTravelInfoResponse(travel);
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/affles/watchout/server/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.affles.watchout.server.global.config;
 
+import com.affles.watchout.server.global.jwt.JwtAuthenticationEntryPoint;
 import com.affles.watchout.server.global.jwt.JwtAuthenticationFilter;
 import com.affles.watchout.server.global.jwt.JwtUtil;
 import com.affles.watchout.server.global.util.RedisUtil;
@@ -22,6 +23,7 @@ public class SecurityConfig {
 
     private final JwtUtil jwtUtil;
     private final RedisUtil redisUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -44,8 +46,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil, redisUtil), UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
-
 }

--- a/server/src/main/java/com/affles/watchout/server/global/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/affles/watchout/server/global/exception/GlobalExceptionHandler.java
@@ -2,40 +2,63 @@ package com.affles.watchout.server.global.exception;
 
 import com.affles.watchout.server.global.common.ApiResponse;
 import com.affles.watchout.server.global.status.ErrorStatus;
-import lombok.extern.slf4j.Slf4j;
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(GeneralException.class)
-    public ResponseEntity<ApiResponse<?>> handleGeneralException(GeneralException e) {
-        ErrorStatus status = e.getErrorStatus();
-        log.warn("[GeneralException] {}", status.getMessage());
-
+    @ExceptionHandler(UserException.class)
+    public ResponseEntity<ApiResponse<?>> handleUserException(UserException e) {
         return ResponseEntity
-                .status(status.getHttpStatus())
+                .status(e.getErrorStatus().getHttpStatus())
                 .body(ApiResponse.onFailure(
-                        status.getMessage(),
-                        status.getHttpStatus().value(),
-                        null
-                ));
+                        e.getErrorStatus().getMessage(),
+                        e.getErrorStatus().getHttpStatus().value(),
+                        null));
+    }
+
+    @ExceptionHandler(TravelException.class)
+    public ResponseEntity<ApiResponse<?>> handleTravelException(TravelException e) {
+        return ResponseEntity
+                .status(e.getErrorStatus().getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        e.getErrorStatus().getMessage(),
+                        e.getErrorStatus().getHttpStatus().value(),
+                        null));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<?>> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldError().getDefaultMessage();
+        return ResponseEntity
+                .status(ErrorStatus._BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        message,
+                        ErrorStatus._BAD_REQUEST.getHttpStatus().value(),
+                        null));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
+        return ResponseEntity
+                .status(ErrorStatus._BAD_REQUEST.getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        e.getMessage(),
+                        ErrorStatus._BAD_REQUEST.getHttpStatus().value(),
+                        null));
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<?>> handleOtherException(Exception e) {
-        log.error("[UnhandledException] ", e);
-        ErrorStatus status = ErrorStatus._INTERNAL_SERVER_ERROR;
-
+    public ResponseEntity<ApiResponse<?>> handleException(Exception e) {
         return ResponseEntity
-                .status(status.getHttpStatus())
+                .status(ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus())
                 .body(ApiResponse.onFailure(
-                        status.getMessage(),
-                        status.getHttpStatus().value(),
-                        null
-                ));
+                        ErrorStatus._INTERNAL_SERVER_ERROR.getMessage(),
+                        ErrorStatus._INTERNAL_SERVER_ERROR.getHttpStatus().value(),
+                        null));
     }
 }

--- a/server/src/main/java/com/affles/watchout/server/global/exception/TravelException.java
+++ b/server/src/main/java/com/affles/watchout/server/global/exception/TravelException.java
@@ -1,0 +1,10 @@
+package com.affles.watchout.server.global.exception;
+
+import com.affles.watchout.server.global.exception.GeneralException;
+import com.affles.watchout.server.global.status.ErrorStatus;
+
+public class TravelException extends GeneralException {
+  public TravelException(ErrorStatus status) {
+    super(status);
+  }
+}

--- a/server/src/main/java/com/affles/watchout/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/server/src/main/java/com/affles/watchout/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.affles.watchout.server.global.jwt;
+
+import com.affles.watchout.server.global.common.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.affles.watchout.server.global.status.ErrorStatus.LOGIN_REQUIRED;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+
+        ApiResponse<?> errorResponse = ApiResponse.onFailure(
+                LOGIN_REQUIRED.getMessage(),
+                LOGIN_REQUIRED.getHttpStatus().value(),
+                null
+        );
+
+        response.setStatus(LOGIN_REQUIRED.getHttpStatus().value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        new ObjectMapper().writeValue(response.getWriter(), errorResponse);
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/global/status/ErrorStatus.java
+++ b/server/src/main/java/com/affles/watchout/server/global/status/ErrorStatus.java
@@ -22,7 +22,12 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않거나 존재하지 않습니다."),
-    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다.");
+    LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인 후 이용 가능합니다."),
+    WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
+
+    // 여행 관련 에러
+    TRAVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "등록한 여행 일정이 없습니다."),
+    TRAVEL_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "출발일과 도착일은 필수입니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## Related Issue 🍀
- close #7 

<br>

## Key Changes 🔑
- JwtAuthenticationEntryPoint 추가
  - 로그인을 아예 안 했을 때 반환하는 것
  → JWT 인증 실패 시, "로그인 후 이용 가능합니다" 메시지와 함께 401 응답 반환
- JwtAuthenticationFilter 개선
  - 로그인은 했는데 토큰이 잘못되었거나 할 때 반환하는 내용임
- GlobalExceptionHandler 수정
  → 사용자(User), 여행(Travel) 관련 예외 및 Validation 예외 공통 포맷으로 응답
- ErrorStatus 추가
  → LOGIN_REQUIRED, WRONG_PASSWORD, TRAVEL_DATE_REQUIRED 등 상세 에러 메시지 정의
- SecurityConfig 수정
  → .exceptionHandling()에 authenticationEntryPoint 등록하여 필터 진입 전 에러 응답 가능하도록 설정

- 여행 일정 등록/조회 API 구현
  - 모두 api/travels 로 통일되지만, 조회 시 user_id를 조회하여 해당 user의 일정만 GET하도록 함
