### PR TITLE
[Feature] #6 - 유저 동의/허용 관련 설정 API 구현

### DIFF
--- a/server/src/main/java/com/affles/watchout/server/domain/user/controller/UserController.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/controller/UserController.java
@@ -1,11 +1,8 @@
 package com.affles.watchout.server.domain.user.controller;
 
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.LoginRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.LoginResponse;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.AlertSettingRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.ConsentSettingRequest;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.*;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.*;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.*;
 import com.affles.watchout.server.domain.user.service.UserService;
 import com.affles.watchout.server.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
@@ -41,52 +38,45 @@ public class UserController {
 
     // 유저 동의 설정 관련
     // (0) 응급 데이터 + 위치 추적 동시 설정
-    @PatchMapping("/consents")
-    public ApiResponse<Void> updateConsents(@RequestBody ConsentSettingRequest request, HttpServletRequest httpRequest) {
-        userService.updateConsentSettings(request, httpRequest);
-        return ApiResponse.onSuccess(null);
+    @PatchMapping("/settings/consents")
+    public ApiResponse<ConsentResponse> updateConsents(@RequestBody ConsentSettingRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateConsentSettings(request, httpRequest));
     }
 
     // (1) 응급 상황 데이터 동의 설정
     @PatchMapping("/settings/emergency")
-    public ApiResponse<Void> updateEmergencyConsent(@RequestParam Boolean value, HttpServletRequest httpRequest) {
-        userService.updateEmergencyConsent(value, httpRequest);
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<EmergencyConsentResponse> updateEmergencyConsent(@RequestBody EmergencyConsentRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateEmergencyConsent(request.getAgreeEmergencyDataShare(), httpRequest));
     }
 
     // (2) 위치 추적 허용 설정
     @PatchMapping("/settings/location")
-    public ApiResponse<Void> updateLocationConsent(@RequestParam Boolean value, HttpServletRequest httpRequest) {
-        userService.updateLocationConsent(value, httpRequest);
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<LocationConsentResponse> updateLocationConsent(@RequestBody LocationConsentRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateLocationConsent(request.getAllowLocationTracking(), httpRequest));
     }
 
     // (3) 진동 + 구조요청 + 보호자번호 동시 설정
-    @PatchMapping("/alerts")
-    public ApiResponse<Void> updateAlertSettings(@RequestBody AlertSettingRequest request, HttpServletRequest httpRequest) {
-        userService.updateAlertSettings(request, httpRequest);
-        return ApiResponse.onSuccess(null);
+    @PatchMapping("/settings/alerts")
+    public ApiResponse<AlertResponse> updateAlertSettings(@RequestBody AlertSettingRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateAlertSettings(request, httpRequest));
     }
 
     // (4) 진동 설정
     @PatchMapping("/settings/vibration")
-    public ApiResponse<Void> updateVibrationAlert(@RequestParam Boolean value, HttpServletRequest httpRequest) {
-        userService.updateVibrationAlert(value, httpRequest);
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<VibrationResponse> updateVibrationAlert(@RequestBody VibrationRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateVibrationAlert(request.getVibrationAlert(), httpRequest));
     }
 
     // (5) 구조 요청 설정
     @PatchMapping("/settings/watch-emergency")
-    public ApiResponse<Void> updateWatchEmergency(@RequestParam Boolean value, HttpServletRequest httpRequest) {
-        userService.updateWatchEmergency(value, httpRequest);
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<WatchEmergencyResponse> updateWatchEmergency(@RequestBody WatchEmergencyRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateWatchEmergency(request.getEnableWatchEmergencySignal(), httpRequest));
     }
 
     // (6) 보호자 번호 설정
     @PatchMapping("/settings/guardian-phone")
-    public ApiResponse<Void> updateGuardianPhone(@RequestParam String phone, HttpServletRequest httpRequest) {
-        userService.updateGuardianPhone(phone, httpRequest);
-        return ApiResponse.onSuccess(null);
+    public ApiResponse<GuardianPhoneResponse> updateGuardianPhone(@RequestBody GuardianPhoneRequest request, HttpServletRequest httpRequest) {
+        return ApiResponse.onSuccess(userService.updateGuardianPhone(request.getGuardianPhone(), httpRequest));
     }
 
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/controller/UserController.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/controller/UserController.java
@@ -4,12 +4,13 @@ import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.LoginReque
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.LoginResponse;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.AlertSettingRequest;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.ConsentSettingRequest;
 import com.affles.watchout.server.domain.user.service.UserService;
 import com.affles.watchout.server.global.common.ApiResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -35,6 +36,56 @@ public class UserController {
     @PostMapping("/logout")
     public ApiResponse<Void> logout(HttpServletRequest request) {
         userService.logout(request);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // 유저 동의 설정 관련
+    // (0) 응급 데이터 + 위치 추적 동시 설정
+    @PatchMapping("/consents")
+    public ApiResponse<Void> updateConsents(@RequestBody ConsentSettingRequest request, HttpServletRequest httpRequest) {
+        userService.updateConsentSettings(request, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // (1) 응급 상황 데이터 동의 설정
+    @PatchMapping("/settings/emergency")
+    public ApiResponse<Void> updateEmergencyConsent(@RequestParam Boolean value, HttpServletRequest httpRequest) {
+        userService.updateEmergencyConsent(value, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // (2) 위치 추적 허용 설정
+    @PatchMapping("/settings/location")
+    public ApiResponse<Void> updateLocationConsent(@RequestParam Boolean value, HttpServletRequest httpRequest) {
+        userService.updateLocationConsent(value, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // (3) 진동 + 구조요청 + 보호자번호 동시 설정
+    @PatchMapping("/alerts")
+    public ApiResponse<Void> updateAlertSettings(@RequestBody AlertSettingRequest request, HttpServletRequest httpRequest) {
+        userService.updateAlertSettings(request, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // (4) 진동 설정
+    @PatchMapping("/settings/vibration")
+    public ApiResponse<Void> updateVibrationAlert(@RequestParam Boolean value, HttpServletRequest httpRequest) {
+        userService.updateVibrationAlert(value, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // (5) 구조 요청 설정
+    @PatchMapping("/settings/watch-emergency")
+    public ApiResponse<Void> updateWatchEmergency(@RequestParam Boolean value, HttpServletRequest httpRequest) {
+        userService.updateWatchEmergency(value, httpRequest);
+        return ApiResponse.onSuccess(null);
+    }
+
+    // (6) 보호자 번호 설정
+    @PatchMapping("/settings/guardian-phone")
+    public ApiResponse<Void> updateGuardianPhone(@RequestParam String phone, HttpServletRequest httpRequest) {
+        userService.updateGuardianPhone(phone, httpRequest);
         return ApiResponse.onSuccess(null);
     }
 

--- a/server/src/main/java/com/affles/watchout/server/domain/user/dto/UserDTO.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/dto/UserDTO.java
@@ -62,4 +62,22 @@ public class UserDTO {
             private String refreshToken;
         }
     }
+
+    public static class UserSettingRequest {
+
+        @Getter
+        @Setter
+        public static class ConsentSettingRequest {
+            private Boolean agreeEmergencyDataShare;
+            private Boolean allowLocationTracking;
+        }
+
+        @Getter
+        @Setter
+        public static class AlertSettingRequest {
+            private Boolean vibrationAlert;
+            private Boolean enableWatchEmergencySignal;
+            private String guardianPhone;
+        }
+    }
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/dto/UserDTO.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/dto/UserDTO.java
@@ -61,6 +61,61 @@ public class UserDTO {
             private String accessToken;
             private String refreshToken;
         }
+
+        @Builder
+        @Getter
+        public static class UserSettingResponse {
+            private Boolean agreeEmergencyDataShare;
+            private Boolean allowLocationTracking;
+            private Boolean vibrationAlert;
+            private Boolean enableWatchEmergencySignal;
+            private String guardianPhone;
+        }
+
+        @Builder
+        @Getter
+        public static class ConsentResponse {
+            private Boolean agreeEmergencyDataShare;
+            private Boolean allowLocationTracking;
+        }
+
+        @Builder
+        @Getter
+        public static class EmergencyConsentResponse {
+            private Boolean agreeEmergencyDataShare;
+        }
+
+        @Builder
+        @Getter
+        public static class LocationConsentResponse {
+            private Boolean allowLocationTracking;
+        }
+
+        @Builder
+        @Getter
+        public static class AlertResponse {
+            private Boolean vibrationAlert;
+            private Boolean enableWatchEmergencySignal;
+            private String guardianPhone;
+        }
+
+        @Builder
+        @Getter
+        public static class VibrationResponse {
+            private Boolean vibrationAlert;
+        }
+
+        @Builder
+        @Getter
+        public static class WatchEmergencyResponse {
+            private Boolean enableWatchEmergencySignal;
+        }
+
+        @Builder
+        @Getter
+        public static class GuardianPhoneResponse {
+            private String guardianPhone;
+        }
     }
 
     public static class UserSettingRequest {
@@ -72,11 +127,41 @@ public class UserDTO {
             private Boolean allowLocationTracking;
         }
 
+        @Builder
+        @Getter
+        public static class EmergencyConsentRequest {
+            private Boolean agreeEmergencyDataShare;
+        }
+
+        @Builder
+        @Getter
+        public static class LocationConsentRequest {
+            private Boolean allowLocationTracking;
+        }
+
         @Getter
         @Setter
         public static class AlertSettingRequest {
             private Boolean vibrationAlert;
             private Boolean enableWatchEmergencySignal;
+            private String guardianPhone;
+        }
+
+        @Builder
+        @Getter
+        public static class VibrationRequest {
+            private Boolean vibrationAlert;
+        }
+
+        @Builder
+        @Getter
+        public static class WatchEmergencyRequest {
+            private Boolean enableWatchEmergencySignal;
+        }
+
+        @Builder
+        @Getter
+        public static class GuardianPhoneRequest {
             private String guardianPhone;
         }
     }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/entity/User.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/entity/User.java
@@ -38,12 +38,16 @@ public class User extends BaseEntity {
 
     // private String connectedWatch; 워치 연결
 
-    // 동의 여부
+    // 동의 여부 필드들
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean vibrationAlert;
 
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean agreeEmergencyDataShare;
 
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean allowLocationTracking;
 
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
     private Boolean enableWatchEmergencySignal;
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/service/UserService.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/service/UserService.java
@@ -1,11 +1,8 @@
 package com.affles.watchout.server.domain.user.service;
 
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.LoginRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.LoginResponse;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.AlertSettingRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.ConsentSettingRequest;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.*;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.*;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.*;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -17,11 +14,11 @@ public interface UserService {
     void logout(HttpServletRequest request);
 
     // 유저 동의 설정 관련
-    void updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader);
-    void updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader);
-    void updateLocationConsent(Boolean value, HttpServletRequest requestHeader);
-    void updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader);
-    void updateVibrationAlert(Boolean value, HttpServletRequest requestHeader);
-    void updateWatchEmergency(Boolean value, HttpServletRequest requestHeader);
-    void updateGuardianPhone(String phone, HttpServletRequest requestHeader);
+    ConsentResponse updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader);
+    EmergencyConsentResponse updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader);
+    LocationConsentResponse updateLocationConsent(Boolean value, HttpServletRequest requestHeader);
+    AlertResponse updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader);
+    VibrationResponse updateVibrationAlert(Boolean value, HttpServletRequest requestHeader);
+    WatchEmergencyResponse updateWatchEmergency(Boolean value, HttpServletRequest requestHeader);
+    GuardianPhoneResponse updateGuardianPhone(String phone, HttpServletRequest requestHeader);
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/service/UserService.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/service/UserService.java
@@ -4,6 +4,8 @@ import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.LoginReque
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.SignUpRequest;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.LoginResponse;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.SignUpResponse;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.AlertSettingRequest;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.ConsentSettingRequest;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,4 +15,13 @@ public interface UserService {
     LoginResponse login(LoginRequest request, HttpServletResponse response);
 
     void logout(HttpServletRequest request);
+
+    // 유저 동의 설정 관련
+    void updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader);
+    void updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader);
+    void updateLocationConsent(Boolean value, HttpServletRequest requestHeader);
+    void updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader);
+    void updateVibrationAlert(Boolean value, HttpServletRequest requestHeader);
+    void updateWatchEmergency(Boolean value, HttpServletRequest requestHeader);
+    void updateGuardianPhone(String phone, HttpServletRequest requestHeader);
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/service/UserServiceImpl.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/service/UserServiceImpl.java
@@ -99,6 +99,9 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public ConsentResponse updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader) {
+        if (request.getAgreeEmergencyDataShare() == null || request.getAllowLocationTracking() == null) {
+            throw new UserException(ErrorStatus.CONSENT_FIELD_REQUIRED);
+        }
         User user = getUser(requestHeader);
         user.setAgreeEmergencyDataShare(request.getAgreeEmergencyDataShare());
         user.setAllowLocationTracking(request.getAllowLocationTracking());
@@ -110,6 +113,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public EmergencyConsentResponse updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader) {
+        if (value == null) throw new UserException(ErrorStatus.EMERGENCY_CONSENT_REQUIRED);
         User user = getUser(requestHeader);
         user.setAgreeEmergencyDataShare(value);
         return EmergencyConsentResponse.builder()
@@ -119,6 +123,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public LocationConsentResponse updateLocationConsent(Boolean value, HttpServletRequest requestHeader) {
+        if (value == null) throw new UserException(ErrorStatus.LOCATION_CONSENT_REQUIRED);
         User user = getUser(requestHeader);
         user.setAllowLocationTracking(value);
         return LocationConsentResponse.builder()
@@ -128,6 +133,9 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public AlertResponse updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader) {
+        if (request.getVibrationAlert() == null || request.getEnableWatchEmergencySignal() == null || request.getGuardianPhone() == null) {
+            throw new UserException(ErrorStatus.ALERT_FIELD_REQUIRED);
+        }
         User user = getUser(requestHeader);
         user.setVibrationAlert(request.getVibrationAlert());
         user.setEnableWatchEmergencySignal(request.getEnableWatchEmergencySignal());
@@ -141,6 +149,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public VibrationResponse updateVibrationAlert(Boolean value, HttpServletRequest requestHeader) {
+        if (value == null) throw new UserException(ErrorStatus.VIBRATION_REQUIRED);
         User user = getUser(requestHeader);
         user.setVibrationAlert(value);
         return VibrationResponse.builder()
@@ -150,6 +159,7 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public WatchEmergencyResponse updateWatchEmergency(Boolean value, HttpServletRequest requestHeader) {
+        if (value == null) throw new UserException(ErrorStatus.WATCH_EMERGENCY_REQUIRED);
         User user = getUser(requestHeader);
         user.setEnableWatchEmergencySignal(value);
         return WatchEmergencyResponse.builder()
@@ -159,6 +169,9 @@ public class UserServiceImpl implements UserService {
 
     @Override
     public GuardianPhoneResponse updateGuardianPhone(String phone, HttpServletRequest requestHeader) {
+        if (phone == null || phone.isBlank()) {
+            throw new UserException(ErrorStatus.GUARDIAN_PHONE_REQUIRED);
+        }
         User user = getUser(requestHeader);
         user.setGuardianPhone(phone);
         return GuardianPhoneResponse.builder()

--- a/server/src/main/java/com/affles/watchout/server/domain/user/service/UserServiceImpl.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/service/UserServiceImpl.java
@@ -3,8 +3,7 @@ package com.affles.watchout.server.domain.user.service;
 import com.affles.watchout.server.domain.user.converter.UserConverter;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.*;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.*;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.AlertSettingRequest;
-import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.ConsentSettingRequest;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.*;
 import com.affles.watchout.server.domain.user.entity.User;
 import com.affles.watchout.server.domain.user.repository.UserRepository;
 import com.affles.watchout.server.global.exception.UserException;
@@ -99,47 +98,71 @@ public class UserServiceImpl implements UserService {
     }
 
     @Override
-    public void updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader) {
+    public ConsentResponse updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setAgreeEmergencyDataShare(request.getAgreeEmergencyDataShare());
         user.setAllowLocationTracking(request.getAllowLocationTracking());
+        return ConsentResponse.builder()
+                .agreeEmergencyDataShare(user.getAgreeEmergencyDataShare())
+                .allowLocationTracking(user.getAllowLocationTracking())
+                .build();
     }
 
     @Override
-    public void updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader) {
+    public EmergencyConsentResponse updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setAgreeEmergencyDataShare(value);
+        return EmergencyConsentResponse.builder()
+                .agreeEmergencyDataShare(user.getAgreeEmergencyDataShare())
+                .build();
     }
 
     @Override
-    public void updateLocationConsent(Boolean value, HttpServletRequest requestHeader) {
+    public LocationConsentResponse updateLocationConsent(Boolean value, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setAllowLocationTracking(value);
+        return LocationConsentResponse.builder()
+                .allowLocationTracking(user.getAllowLocationTracking())
+                .build();
     }
 
     @Override
-    public void updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader) {
+    public AlertResponse updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setVibrationAlert(request.getVibrationAlert());
         user.setEnableWatchEmergencySignal(request.getEnableWatchEmergencySignal());
         user.setGuardianPhone(request.getGuardianPhone());
+        return AlertResponse.builder()
+                .vibrationAlert(user.getVibrationAlert())
+                .enableWatchEmergencySignal(user.getEnableWatchEmergencySignal())
+                .guardianPhone(user.getGuardianPhone())
+                .build();
     }
 
     @Override
-    public void updateVibrationAlert(Boolean value, HttpServletRequest requestHeader) {
+    public VibrationResponse updateVibrationAlert(Boolean value, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setVibrationAlert(value);
+        return VibrationResponse.builder()
+                .vibrationAlert(user.getVibrationAlert())
+                .build();
     }
 
     @Override
-    public void updateWatchEmergency(Boolean value, HttpServletRequest requestHeader) {
+    public WatchEmergencyResponse updateWatchEmergency(Boolean value, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setEnableWatchEmergencySignal(value);
+        return WatchEmergencyResponse.builder()
+                .enableWatchEmergencySignal(user.getEnableWatchEmergencySignal())
+                .build();
     }
 
     @Override
-    public void updateGuardianPhone(String phone, HttpServletRequest requestHeader) {
+    public GuardianPhoneResponse updateGuardianPhone(String phone, HttpServletRequest requestHeader) {
         User user = getUser(requestHeader);
         user.setGuardianPhone(phone);
+        return GuardianPhoneResponse.builder()
+                .guardianPhone(user.getGuardianPhone())
+                .build();
     }
 }

--- a/server/src/main/java/com/affles/watchout/server/domain/user/service/UserServiceImpl.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/user/service/UserServiceImpl.java
@@ -3,6 +3,8 @@ package com.affles.watchout.server.domain.user.service;
 import com.affles.watchout.server.domain.user.converter.UserConverter;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserRequest.*;
 import com.affles.watchout.server.domain.user.dto.UserDTO.UserResponse.*;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.AlertSettingRequest;
+import com.affles.watchout.server.domain.user.dto.UserDTO.UserSettingRequest.ConsentSettingRequest;
 import com.affles.watchout.server.domain.user.entity.User;
 import com.affles.watchout.server.domain.user.repository.UserRepository;
 import com.affles.watchout.server.global.exception.UserException;
@@ -90,4 +92,54 @@ public class UserServiceImpl implements UserService {
         redisUtil.addTokenToBlacklist(token, expiration);
     }
 
+    // 유저 동의 설정 관련
+    private User getUser(HttpServletRequest request) {
+        Long userId = jwtUtil.getUserId(jwtUtil.resolveToken(request));
+        return userRepository.findById(userId).orElseThrow(() -> new UserException(ErrorStatus.USER_NOT_FOUND));
+    }
+
+    @Override
+    public void updateConsentSettings(ConsentSettingRequest request, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setAgreeEmergencyDataShare(request.getAgreeEmergencyDataShare());
+        user.setAllowLocationTracking(request.getAllowLocationTracking());
+    }
+
+    @Override
+    public void updateEmergencyConsent(Boolean value, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setAgreeEmergencyDataShare(value);
+    }
+
+    @Override
+    public void updateLocationConsent(Boolean value, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setAllowLocationTracking(value);
+    }
+
+    @Override
+    public void updateAlertSettings(AlertSettingRequest request, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setVibrationAlert(request.getVibrationAlert());
+        user.setEnableWatchEmergencySignal(request.getEnableWatchEmergencySignal());
+        user.setGuardianPhone(request.getGuardianPhone());
+    }
+
+    @Override
+    public void updateVibrationAlert(Boolean value, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setVibrationAlert(value);
+    }
+
+    @Override
+    public void updateWatchEmergency(Boolean value, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setEnableWatchEmergencySignal(value);
+    }
+
+    @Override
+    public void updateGuardianPhone(String phone, HttpServletRequest requestHeader) {
+        User user = getUser(requestHeader);
+        user.setGuardianPhone(phone);
+    }
 }

--- a/server/src/main/java/com/affles/watchout/server/global/status/ErrorStatus.java
+++ b/server/src/main/java/com/affles/watchout/server/global/status/ErrorStatus.java
@@ -25,6 +25,15 @@ public enum ErrorStatus implements BaseErrorCode {
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "로그인 후 이용 가능합니다."),
     WRONG_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 틀렸습니다."),
 
+    // 사용자 동의/허용 관련 에러
+    GUARDIAN_PHONE_REQUIRED(HttpStatus.BAD_REQUEST, "보호자 연락처는 필수입니다."),
+    CONSENT_FIELD_REQUIRED(HttpStatus.BAD_REQUEST, "응급 데이터 공유 허용 및 위치 추적 허용 필드는 모두 필수입니다."),
+    EMERGENCY_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "응급 상황 데이터 공유 동의 여부는 필수입니다."),
+    LOCATION_CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "위치 추적 허용 여부는 필수입니다."),
+    ALERT_FIELD_REQUIRED(HttpStatus.BAD_REQUEST, "진동, 구조 요청, 보호자 번호는 모두 필수입니다."),
+    VIBRATION_REQUIRED(HttpStatus.BAD_REQUEST, "진동 알림 여부는 필수입니다."),
+    WATCH_EMERGENCY_REQUIRED(HttpStatus.BAD_REQUEST, "긴급 구조 요청 여부는 필수입니다."),
+
     // 여행 관련 에러
     TRAVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "등록한 여행 일정이 없습니다."),
     TRAVEL_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "출발일과 도착일은 필수입니다."),


### PR DESCRIPTION
## Related Issue 🍀
- close #6 

<br>

## Key Changes 🔑
- (0) 응급 데이터 + 위치 추적 동시 설정(회원가입 후 두 가지 동시에 설정하는 화면을 위한 API)
- (1) 응급 상황 데이터 동의 설정
- (2) 위치 추적 허용 설정
- (3) 진동 + 구조요청 + 보호자번호 동시 설정(회원가입 후 세 가지 동시에 설정하는 화면을 위한 API)
- (4) 진동 설정
- (5) 구조 요청 설정
- (6) 보호자 번호 설정