### PR TITLE
[Feature] #16 - 해외 재난 경보 API 연동 및 response 구조 맞춤 설정

### DIFF
--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/controller/NaturalDisasterController.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/controller/NaturalDisasterController.java
@@ -1,0 +1,44 @@
+package com.affles.watchout.server.domain.disaster.controller;
+
+import com.affles.watchout.server.domain.disaster.dto.SimpleNotification;
+import com.affles.watchout.server.domain.disaster.dto.NaturalDisasterEventResponse;
+import com.affles.watchout.server.domain.disaster.service.NaturalDisasterService;
+import com.affles.watchout.server.global.common.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/disasters")
+@Validated
+public class NaturalDisasterController {
+
+    private final NaturalDisasterService naturalDisasterService;
+
+    @Autowired
+    public NaturalDisasterController(NaturalDisasterService naturalDisasterService) {
+        this.naturalDisasterService = naturalDisasterService;
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<SimpleNotification>>> getLatestDisaster(
+            @RequestParam("lat") double lat,
+            @RequestParam("lng") double lng) {
+
+        // 1) 서비스 호출 → 예외 발생 시 GlobalExceptionHandler에게 위임
+        NaturalDisasterEventResponse[] events = naturalDisasterService.fetchLatestDisasters(lat, lng);
+
+        // 2) SimpleNotification 리스트로 변환
+        List<SimpleNotification> notifications = naturalDisasterService.toSimpleNotificationList(events);
+
+        // 3) 최신 1건만 꺼내서 반환 (서비스 레이어에서 데이터 없을 경우 이미 예외가 던져짐)
+        List<SimpleNotification> single = Collections.singletonList(notifications.get(0));
+        ApiResponse<List<SimpleNotification>> response = ApiResponse.onSuccess(single);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/controller/NaturalDisasterSseController.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/controller/NaturalDisasterSseController.java
@@ -1,0 +1,63 @@
+// sse 설정 코드 - 현재 사용 X
+package com.affles.watchout.server.domain.disaster.controller;
+
+import com.affles.watchout.server.domain.disaster.dto.SimpleNotification;
+import com.affles.watchout.server.domain.disaster.dto.NaturalDisasterEventResponse;
+import com.affles.watchout.server.domain.disaster.service.NaturalDisasterService;
+import com.affles.watchout.server.global.common.ApiResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+public class NaturalDisasterSseController {
+
+    private final NaturalDisasterService naturalDisasterService;
+
+    @Autowired
+    public NaturalDisasterSseController(NaturalDisasterService naturalDisasterService) {
+        this.naturalDisasterService = naturalDisasterService;
+    }
+
+    @GetMapping(path = "/sse/disasters", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter streamDisasters(
+            @RequestParam("lat") double lat,
+            @RequestParam("lng") double lng) {
+
+        SseEmitter emitter = new SseEmitter(0L);
+
+        try {
+            // 1) Ambee API 호출 (서비스 레이어에서 예외 발생 가능)
+            NaturalDisasterEventResponse[] events =
+                    naturalDisasterService.fetchLatestDisasters(lat, lng);
+
+            // 2) SimpleNotification 리스트로 변환 (최대 1개)
+            List<SimpleNotification> allNotifications =
+                    naturalDisasterService.toSimpleNotificationList(events);
+
+            // 3) 첫 번째 알림만 꺼내서 전달
+            List<SimpleNotification> singleNotificationList =
+                    Collections.singletonList(allNotifications.get(0));
+
+            // 4) ApiResponse 성공 형태로 감싸서 전송
+            ApiResponse<List<SimpleNotification>> response =
+                    ApiResponse.onSuccess(singleNotificationList);
+            emitter.send(response);
+
+        } catch (IOException e) {
+            // 5) SseEmitter.send() 중 IOException 발생 시 스트림 종료
+            emitter.completeWithError(e);
+            return emitter;
+        }
+        // 6) 정상적으로 한 번 전송 후 스트림 종료
+        emitter.complete();
+        return emitter;
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/DisasterAlertMessage.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/DisasterAlertMessage.java
@@ -1,0 +1,28 @@
+// sse용 DTO라 현재 사용 X
+package com.affles.watchout.server.domain.disaster.dto;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class DisasterAlertMessage {
+
+    private String type;                    // ex) "EQ", "WF", "FD", "TC" 등 (event_type)
+    private String eventName;               // ex) "Earthquake", "Fire incident" 등 (event_name)
+    private String date;                    // 이벤트 발생 일시 (String 형태)
+
+    private double latitude;                // 위도
+    private double longitude;               // 경도
+
+    private String proximitySeverityLevel;  // 근접 심각도 레벨 (예: "Low Risk")
+    private String defaultAlertLevels;      // 기본 알림 레벨 (예: "Orange")
+    private String estimatedEndDate;        // 예상 종료 시각
+
+    // 지진 전용 정보 (지진이 아닐 땐 0.0, null)
+    private double magnitude;               // ex) 4.2 (지진 전용)
+    private double alertScore;              // ex) 0.85 (지진 전용)
+    private String severity;                // ex) "moderate" (지진 전용)
+
+    private LocalDateTime timestamp;        // 서버가 메시지를 생성한 시각
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/NaturalDisasterApiResponse.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/NaturalDisasterApiResponse.java
@@ -1,0 +1,25 @@
+package com.affles.watchout.server.domain.disaster.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaturalDisasterApiResponse {
+
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("hasNextPage")
+    private boolean hasNextPage;
+
+    @JsonProperty("page")
+    private int page;
+
+    @JsonProperty("limit")
+    private int limit;
+
+    @JsonProperty("result")
+    private NaturalDisasterEventResponse[] result;
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/NaturalDisasterEventResponse.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/NaturalDisasterEventResponse.java
@@ -1,0 +1,52 @@
+package com.affles.watchout.server.domain.disaster.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaturalDisasterEventResponse {
+
+    // 이벤트 타입 ("EQ"=지진, "WF"=산불, "FD"=홍수, "TC"=태풍 등)
+    @JsonProperty("event_type")
+    private String eventType;
+
+    // 이벤트 이름 (예: "Earthquake", "Fire incident" 등)
+    @JsonProperty("event_name")
+    private String eventName;
+
+    // 이벤트 발생 날짜/시간 (예: "2025-05-23 00:00:00")
+    @JsonProperty("date")
+    private String date;
+
+    // 위도
+    @JsonProperty("lat")
+    private Double latitude;
+
+    // 경도
+    @JsonProperty("lng")
+    private Double longitude;
+
+    // 재난 근접 심각도 레벨 (“Low Risk”, “Moderate Risk” 등)
+    @JsonProperty("proximity_severity_level")
+    private String proximitySeverityLevel;
+
+    // 기본 알림 레벨 (“Green”, “Orange”, “Red” 등)
+    @JsonProperty("default_alert_levels")
+    private String defaultAlertLevels;
+
+    // 이벤트 예상 종료일 (예: "2025-06-22T22:55:02.000Z")
+    @JsonProperty("estimated_end_date")
+    private String estimatedEndDate;
+
+    // (지진 전용)
+    @JsonProperty("magnitude")
+    private Double magnitude;
+
+    @JsonProperty("alert_score")
+    private Double alertScore;
+
+    @JsonProperty("severity")
+    private String severity;
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/SimpleNotification.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/dto/SimpleNotification.java
@@ -1,0 +1,11 @@
+package com.affles.watchout.server.domain.disaster.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class SimpleNotification {
+    private String title;
+    private String contents;
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/service/DisasterTypeMapper.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/service/DisasterTypeMapper.java
@@ -1,0 +1,19 @@
+package com.affles.watchout.server.domain.disaster.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class DisasterTypeMapper {
+    private static final Map<String, String> typeToKorean = new HashMap<>();
+
+    static {
+        typeToKorean.put("EQ", "지진");
+        typeToKorean.put("WF", "산불");
+        typeToKorean.put("FD", "홍수");
+        typeToKorean.put("TC", "태풍");
+    }
+
+    public static String toKorean(String eventType) {
+        return typeToKorean.getOrDefault(eventType, "재난");
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/service/NaturalDisasterService.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/service/NaturalDisasterService.java
@@ -1,0 +1,15 @@
+package com.affles.watchout.server.domain.disaster.service;
+
+import com.affles.watchout.server.domain.disaster.dto.NaturalDisasterEventResponse;
+import com.affles.watchout.server.domain.disaster.dto.SimpleNotification;
+
+import java.util.List;
+
+public interface NaturalDisasterService {
+
+    NaturalDisasterEventResponse[] fetchLatestDisasters(double latitude, double longitude);
+
+    SimpleNotification toSimpleNotification(NaturalDisasterEventResponse resp);
+
+    List<SimpleNotification> toSimpleNotificationList(NaturalDisasterEventResponse[] events);
+}

--- a/server/src/main/java/com/affles/watchout/server/domain/disaster/service/NaturalDisasterServiceImpl.java
+++ b/server/src/main/java/com/affles/watchout/server/domain/disaster/service/NaturalDisasterServiceImpl.java
@@ -1,0 +1,108 @@
+package com.affles.watchout.server.domain.disaster.service;
+
+import com.affles.watchout.server.domain.disaster.dto.NaturalDisasterApiResponse;
+import com.affles.watchout.server.domain.disaster.dto.NaturalDisasterEventResponse;
+import com.affles.watchout.server.domain.disaster.dto.SimpleNotification;
+import com.affles.watchout.server.global.exception.DisasterException;
+import com.affles.watchout.server.global.status.ErrorStatus;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class NaturalDisasterServiceImpl implements NaturalDisasterService {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${ambee.naturaldisasters.base-url}")
+    private String ambeeBaseUrl;
+
+    @Value("${ambee.api.key}")
+    private String ambeeApiKey;
+
+    public NaturalDisasterServiceImpl(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
+
+    @Override
+    public NaturalDisasterEventResponse[] fetchLatestDisasters(double latitude, double longitude) {
+        // 1) 파라미터 범위 검증
+        if (latitude < -90.0 || latitude > 90.0 || longitude < -180.0 || longitude > 180.0) {
+            throw new DisasterException(ErrorStatus.DISASTER_PARAM_INVALID);
+        }
+
+        // 2) Ambee API URL 조합 (최신 1개만 가져옴)
+        String url = String.format(
+                "%s/disasters/latest/by-lat-lng?lat=%f&lng=%f&limit=1&page=1",
+                ambeeBaseUrl, latitude, longitude
+        );
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("x-api-key", ambeeApiKey);
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+
+        NaturalDisasterApiResponse apiResp;
+        try {
+            // 3) REST 호출 (RestClientException 발생 가능)
+            ResponseEntity<NaturalDisasterApiResponse> responseEntity =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, NaturalDisasterApiResponse.class);
+            apiResp = responseEntity.getBody();
+        } catch (RestClientException rcEx) {
+            // 외부 API 호출 실패 시
+            throw new DisasterException(
+                    ErrorStatus.DISASTER_EXTERNAL_API_ERROR,
+                    "Ambee API 호출 실패: " + rcEx.getMessage()
+            );
+        }
+
+        // 4) 결과가 null이거나 비어 있으면 Not Found 예외
+        if (apiResp == null || apiResp.getResult() == null || apiResp.getResult().length == 0) {
+            throw new DisasterException(ErrorStatus.DISASTER_NOT_FOUND);
+        }
+
+        // 5) 정상일 경우, 이벤트 배열 리턴
+        return apiResp.getResult();
+    }
+
+    @Override
+    public SimpleNotification toSimpleNotification(NaturalDisasterEventResponse resp) {
+        if (resp == null) {
+            return null;
+        }
+
+        // eventType 코드 → 한국어 재난명
+        String koreanType = DisasterTypeMapper.toKorean(resp.getEventType());
+
+        // title 예: "실시간 (지진) 안내"
+        String title = String.format("실시간 (%s) 안내", koreanType);
+
+        // contents 예: "현재 지역에 지진이 발생했습니다"
+        String contents = String.format("현재 지역에 %s이 발생했습니다", koreanType);
+
+        return new SimpleNotification(title, contents);
+    }
+
+    @Override
+    public List<SimpleNotification> toSimpleNotificationList(NaturalDisasterEventResponse[] events) {
+        if (events == null || events.length == 0) {
+            return Collections.emptyList();
+        }
+        List<SimpleNotification> list = new ArrayList<>();
+        for (NaturalDisasterEventResponse ev : events) {
+            SimpleNotification sn = toSimpleNotification(ev);
+            if (sn != null) {
+                list.add(sn);
+            }
+        }
+        return list;
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/global/config/RestTemplateConfig.java
+++ b/server/src/main/java/com/affles/watchout/server/global/config/RestTemplateConfig.java
@@ -1,0 +1,18 @@
+package com.affles.watchout.server.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5 * 1000);
+        factory.setReadTimeout(5 * 1000);
+        return builder.requestFactory(() -> factory).build();
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/global/config/SecurityConfig.java
+++ b/server/src/main/java/com/affles/watchout/server/global/config/SecurityConfig.java
@@ -43,6 +43,8 @@ public class SecurityConfig {
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/users/signup", "/api/users/login").permitAll()
+                        // .requestMatchers("/sse/disasters", "/sse/disasters/**").permitAll()
+
                         .anyRequest().authenticated()
                 )
                 .exceptionHandling(ex -> ex

--- a/server/src/main/java/com/affles/watchout/server/global/exception/DisasterException.java
+++ b/server/src/main/java/com/affles/watchout/server/global/exception/DisasterException.java
@@ -1,0 +1,14 @@
+package com.affles.watchout.server.global.exception;
+
+import com.affles.watchout.server.global.status.ErrorStatus;
+
+public class DisasterException extends GeneralException {
+
+    public DisasterException(ErrorStatus errorStatus) {
+        super(errorStatus);
+    }
+
+    public DisasterException(ErrorStatus errorStatus, String detailMessage) {
+        super(errorStatus);
+    }
+}

--- a/server/src/main/java/com/affles/watchout/server/global/exception/GlobalExceptionHandler.java
+++ b/server/src/main/java/com/affles/watchout/server/global/exception/GlobalExceptionHandler.java
@@ -52,6 +52,16 @@ public class GlobalExceptionHandler {
                         null));
     }
 
+    @ExceptionHandler(DisasterException.class)
+    public ResponseEntity<ApiResponse<?>> handleDisasterException(DisasterException e) {
+        return ResponseEntity
+                .status(e.getErrorStatus().getHttpStatus())
+                .body(ApiResponse.onFailure(
+                        e.getErrorStatus().getMessage(),
+                        e.getErrorStatus().getHttpStatus().value(),
+                        null));
+    }
+
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<?>> handleConstraintViolationException(ConstraintViolationException e) {
         return ResponseEntity

--- a/server/src/main/java/com/affles/watchout/server/global/exception/TravelException.java
+++ b/server/src/main/java/com/affles/watchout/server/global/exception/TravelException.java
@@ -4,7 +4,5 @@ import com.affles.watchout.server.global.exception.GeneralException;
 import com.affles.watchout.server.global.status.ErrorStatus;
 
 public class TravelException extends GeneralException {
-  public TravelException(ErrorStatus status) {
-    super(status);
-  }
+  public TravelException(ErrorStatus status) { super(status); }
 }

--- a/server/src/main/java/com/affles/watchout/server/global/status/ErrorStatus.java
+++ b/server/src/main/java/com/affles/watchout/server/global/status/ErrorStatus.java
@@ -43,7 +43,12 @@ public enum ErrorStatus implements BaseErrorCode {
     SPOT_DATE_REQUIRED(HttpStatus.BAD_REQUEST, "장소 날짜는 필수입니다."),
     SPOT_FORBIDDEN(HttpStatus.FORBIDDEN, "해당 장소에 접근할 수 없습니다."),
     SPOT_NAME_REQUIRED(HttpStatus.BAD_REQUEST, "장소명이 필요합니다."),
-    SPOT_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, "장소 상세 주소가 필요합니다.");
+    SPOT_DETAIL_REQUIRED(HttpStatus.BAD_REQUEST, "장소 상세 주소가 필요합니다."),
+
+    // 자연재해 관련 에러
+    DISASTER_PARAM_INVALID(HttpStatus.BAD_REQUEST, "잘못된 위도/경도 입니다."),
+    DISASTER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 위치에 재난 이벤트가 존재하지 않습니다."),
+    DISASTER_EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "외부 재난 정보 조회에 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -27,3 +27,9 @@ spring:
     level:
       org.springframework: DEBUG
       org.hibernate.SQL: DEBUG
+
+ambee:
+  naturaldisasters:
+    base-url: https://api.ambeedata.com
+  api:
+    key: ${AMBEE_API_KEY}


### PR DESCRIPTION
## Related Issue 🍀
- #16 

<br>

## Key Changes 🔑
- ambee를 이용해 해외의 재난경보를 불러옴(지진, 산불, 홍수, 태풍)
- 해당 내용을 client 맞춤형 response로 수정함(title, content)
